### PR TITLE
EWB-2528: Update SDK version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 * None.
 
 ##### New Features
-* None.
+* Added support for SDK version 0.35.0.
 
 ##### Enhancements
 * None.

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     python_requires='>=3.7',
     py_modules=[splitext(basename(path))[0] for path in glob('src/**/*.py')],
     install_requires=[
-        "zepben.evolve==0.35.0b2",
+        "zepben.evolve==0.35.0b4",
         "pandapower==2.9.0"
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     python_requires='>=3.7',
     py_modules=[splitext(basename(path))[0] for path in glob('src/**/*.py')],
     install_requires=[
-        "zepben.evolve==0.35.0b5",
+        "zepben.evolve==0.35.0b6",
         "pandapower==2.9.0"
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     python_requires='>=3.7',
     py_modules=[splitext(basename(path))[0] for path in glob('src/**/*.py')],
     install_requires=[
-        "zepben.evolve==0.35.0b1",
+        "zepben.evolve==0.35.0b2",
         "pandapower==2.9.0"
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     python_requires='>=3.7',
     py_modules=[splitext(basename(path))[0] for path in glob('src/**/*.py')],
     install_requires=[
-        "zepben.evolve==0.35.0b4",
+        "zepben.evolve==0.35.0b5",
         "pandapower==2.9.0"
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     python_requires='>=3.7',
     py_modules=[splitext(basename(path))[0] for path in glob('src/**/*.py')],
     install_requires=[
-        "zepben.evolve==0.35.0b6",
+        "zepben.evolve==0.35.0b7",
         "pandapower==2.9.0"
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     python_requires='>=3.7',
     py_modules=[splitext(basename(path))[0] for path in glob('src/**/*.py')],
     install_requires=[
-        "zepben.evolve==0.34.0",
+        "zepben.evolve==0.35.0b1",
         "pandapower==2.9.0"
     ],
     extras_require={


### PR DESCRIPTION
# Description

Simple dependency update to avoid conflicts in the ewb examples repo.

# Associated tasks:

Tasks blocking this one:
- [x] https://github.com/zepben/evolve-sdk-python/pull/116
- [x] https://github.com/zepben/evolve-sdk-python/pull/115
- [x] https://github.com/zepben/evolve-sdk-python/pull/118
- [x] https://github.com/zepben/evolve-sdk-python/pull/119
- [x] https://github.com/zepben/evolve-sdk-python/pull/120

Tasks this is blocking:
- https://github.com/zepben/ewb-sdk-examples-python/pull/2

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have updated the changelog.
