### PR TITLE
EWB-3141: Allow location-less lines

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,8 @@
 * None.
 
 ##### Fixes
-* None.
+* Fix bug where attempting to translate lines using `BasicPandaPowerNetworkCreator` resulted in an error if the lines
+  did not have `Location`s.
 
 ##### Notes
 * None.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from os.path import splitext
 
 from setuptools import setup, find_packages
 
-test_deps = ["pytest", "pytest-cov", "pytest-asyncio", "hypothesis<6"]
+test_deps = ["pytest", "pytest-cov", "pytest-asyncio", "hypothesis"]
 setup(
     name="pp-translator",
     description="Library for translating Zepben CIM network models to pandapower models",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     python_requires='>=3.7',
     py_modules=[splitext(basename(path))[0] for path in glob('src/**/*.py')],
     install_requires=[
-        "zepben.evolve==0.35.0b7",
+        "zepben.evolve==0.35.0b9",
         "pandapower==2.9.0"
     ],
     extras_require={

--- a/src/pp_creators/basic_creator.py
+++ b/src/pp_creators/basic_creator.py
@@ -96,7 +96,9 @@ class BasicPandaPowerNetworkCreator(
         else:
             acls_series = list(collapsed_ac_line_segments)
         locations: List[Location] = [acls.location for acls in acls_series if acls.location]
-        coords = [(p.x_position, p.y_position) for p in locations[0].points]
+        coords = []
+        if locations:
+            coords = [(p.x_position, p.y_position) for p in locations[0].points]
         if len(locations) >= 2:
             next_coords = [(p.x_position, p.y_position) for p in locations[1].points]
             # Make sure we start the coordinates in the right direction

--- a/test/pp_creators/conftest.py
+++ b/test/pp_creators/conftest.py
@@ -6,13 +6,14 @@
 
 from typing import List
 
-from pytest import fixture
+import pytest_asyncio
 from zepben.evolve import PhaseCode, NetworkService, BaseVoltage, EnergySource, Terminal, ConductingEquipment, \
     AcLineSegment, PerLengthSequenceImpedance, \
-    PowerTransformer, PowerTransformerEnd, EnergyConsumer, OverheadWireInfo, PowerTransformerInfo, EnergySourcePhase
+    PowerTransformer, PowerTransformerEnd, EnergyConsumer, OverheadWireInfo, PowerTransformerInfo, EnergySourcePhase, \
+    set_phases, set_direction, Feeder
 
 
-@fixture()
+@pytest_asyncio.fixture()
 async def simple_node_breaker_network() -> NetworkService:
     # Network
     network = NetworkService()
@@ -63,6 +64,10 @@ async def simple_node_breaker_network() -> NetworkService:
     es_t = _create_terminal(es)
     network.add(es_t)
 
+    # Feeder
+    fdr = Feeder(mrid="feeder", name="Feeder", normal_head_terminal=es_t)
+    network.add(fdr)
+
     # Transformer
     tx = PowerTransformer(mrid="transformer", name="Transformer")
     tx.asset_info = pt_info
@@ -97,7 +102,8 @@ async def simple_node_breaker_network() -> NetworkService:
 
     network.connect_terminals(line_terminals[1], ec_t)
 
-    await network.set_phases()
+    await set_direction().run(network)
+    await set_phases().run(network)
     return network
 
 

--- a/test/pp_creators/test_create_pp_bus_branch.py
+++ b/test/pp_creators/test_create_pp_bus_branch.py
@@ -3,135 +3,149 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import logging
+
+import numpy
+import pytest as pytest
+import pandapower as pp
+
+from pp_creators.basic_creator import BasicPandaPowerNetworkCreator
+from pp_test_utils import validate_pp_load_flow_results
+
 
 # Refer to pandapower's simple 3-bus network example: https://www.pandapower.org/start/#a-short-introduction-
 
-# TODO: This test cannot run until the python sdk setPhases() method is fixed
-# @pytest.mark.asyncio
-# async def test_create_pp_bus_branch_model(simple_node_breaker_network):
-#     node_breaker_model = simple_node_breaker_network
-#     creator = PandaPowerNetworkCreator(vm_pu=1.02, logger=logging.getLogger())
-#     result = await creator.create(node_breaker_model)
-#
-#     assert result.was_successful
-#
-#     # Run Load Flow
-#     pp.diagnostic(result.network)
-#     pp.runpp(result.network)
-#     pp_network = result.network
-#
-#     # Determine busses
-#     tx_terminals_sorted_by_voltage = [end.terminal
-#                                       for end in sorted(list(simple_node_breaker_network.get("transformer").ends),
-#                                                         key=lambda x: x.rated_u,
-#                                                         reverse=True)]
-#     tx_hv_terminal = tx_terminals_sorted_by_voltage[0]
-#     tx_lv_terminal = tx_terminals_sorted_by_voltage[1]
-#     tx_hv_bus = next(iter(result.mappings.to_bbn.objects[tx_hv_terminal.mrid]))
-#     tx_lv_bus = next(iter(result.mappings.to_bbn.objects[tx_lv_terminal.mrid]))
-#     load_bus = next(
-#         iter(result.mappings.to_bbn.objects[list(simple_node_breaker_network.get("load").terminals)[0].mrid]))
-#
-#     # Validate and Log
-#     validate_pp_load_flow_results(
-#         pp_network.bus,
-#         [
-#             {"name": "bus_None", "vn_kv": 0.4, "type": "b", "in_service": True, "zone": None},
-#             {"name": "bus_None", "vn_kv": 0.4, "type": "b", "in_service": True, "zone": None},
-#             {"name": "bus_None", "vn_kv": 20.0, "type": "b", "in_service": True, "zone": None},
-#         ],
-#         "bus",
-#         log=True
-#     )
-#
-#     validate_pp_load_flow_results(
-#         pp_network.trafo,
-#         [
-#             {
-#                 "name": "Transformer",
-#                 "std_type": "0.4 MVA 20/0.4 kV",
-#                 "hv_bus": tx_hv_bus,
-#                 "lv_bus": tx_lv_bus,
-#                 "sn_mva": 0.4,
-#                 "vn_hv_kv": 20.0,
-#                 "vn_lv_kv": 0.4,
-#                 "vk_percent": 6.0,
-#                 "vkr_percent": 1.425,
-#                 "pfe_kw": 1.35,
-#                 "i0_percent": 0.3375,
-#                 "shift_degree": 150,
-#                 "tap_side": "hv",
-#                 "tap_neutral": 0,
-#                 "tap_min": -2,
-#                 "tap_max": 2,
-#                 "tap_step_percent": 2.5,
-#                 "tap_step_degree": 0.0,
-#                 "tap_pos": 0,
-#                 "tap_phase_shifter": False,
-#                 "parallel": 1,
-#                 "df": 1.0,
-#                 "in_service": True
-#             }
-#         ],
-#         "trafo",
-#         log=True
-#     )
-#
-#     validate_pp_load_flow_results(
-#         pp_network.line,
-#         [
-#             {
-#                 "name": "line_None",
-#                 "std_type": "NAYY 4x50 SE",
-#                 "from_bus": [tx_lv_bus, load_bus],
-#                 "to_bus": [tx_lv_bus, load_bus],
-#                 "length_km": 0.1,
-#                 "r_ohm_per_km": 0.642,
-#                 "x_ohm_per_km": 0.083,
-#                 "c_nf_per_km": 210,
-#                 "g_us_per_km": 0.0,
-#                 "max_i_ka": 0.142,
-#                 "df": 1.0,
-#                 "parallel": 1,
-#                 "type": "cs",
-#                 "in_service": True
-#             }
-#         ],
-#         "line",
-#         log=True
-#     )
-#
-#     validate_pp_load_flow_results(
-#         pp_network.load,
-#         [
-#             {
-#                 "name": "Load",
-#                 "bus": load_bus,
-#                 "p_mw": 0.1,
-#                 "q_mvar": 0.05,
-#                 "const_z_percent": 0.0,
-#                 "const_i_percent": 0.0,
-#                 "sn_mva": pp.nan,
-#                 "scaling": 1.0,
-#                 "in_service": True,
-#                 "type": "wye"
-#             }
-#         ],
-#         "load",
-#         log=True
-#     )
-#
-#     validate_pp_load_flow_results(
-#         pp_network.ext_grid,
-#         [
-#             {
-#                 "name": "Grid Connection",
-#                 "bus": tx_hv_bus,
-#                 "vm_pu": 1.02,
-#                 "va_degree": 0.0,
-#                 "in_service": True
-#             }
-#         ],
-#         "ext_grid",
-#         log=True
-#     )
+@pytest.mark.asyncio
+async def test_create_pp_bus_branch_model(simple_node_breaker_network):
+    node_breaker_model = simple_node_breaker_network
+    creator = BasicPandaPowerNetworkCreator(vm_pu=1.02, ec_load_provider=lambda _: (100_000, 50_000),
+                                            logger=logging.getLogger())
+    result = await creator.create(node_breaker_model)
+
+    assert result.was_successful
+
+    # Run Load Flow
+    pp.diagnostic(result.network)
+    pp.runpp(result.network)
+    pp_network = result.network
+
+    # Determine busses
+    tx_terminals_sorted_by_voltage = [end.terminal
+                                      for end in sorted(list(simple_node_breaker_network.get("transformer").ends),
+                                                        key=lambda x: x.rated_u,
+                                                        reverse=True)]
+    tx_hv_terminal = tx_terminals_sorted_by_voltage[0]
+    tx_lv_terminal = tx_terminals_sorted_by_voltage[1]
+    tx_hv_bus = next(iter(result.mappings.to_bbn.objects[tx_hv_terminal.mrid])).index
+    tx_lv_bus = next(iter(result.mappings.to_bbn.objects[tx_lv_terminal.mrid])).index
+    load_bus = next(
+        iter(result.mappings.to_bbn.objects[list(simple_node_breaker_network.get("load").terminals)[0].mrid])
+    ).index
+
+    # Validate and Log
+    validate_pp_load_flow_results(
+        pp_network.bus,
+        [
+            {"name": "bus_None", "vn_kv": 0.4, "type": "b", "in_service": True, "zone": None},
+            {"name": "bus_None", "vn_kv": 0.4, "type": "b", "in_service": True, "zone": None},
+            {"name": "bus_None", "vn_kv": 20.0, "type": "b", "in_service": True, "zone": None},
+        ],
+        "bus",
+        log=True
+    )
+
+    validate_pp_load_flow_results(
+        pp_network.trafo,
+        [
+            {
+                "name": "Transformer",
+                "std_type": None,
+                "hv_bus": tx_hv_bus,
+                "lv_bus": tx_lv_bus,
+                "sn_mva": 1.0,
+                "vn_hv_kv": 20.0,
+                "vn_lv_kv": 0.4,
+                "vk_percent": 5.0,
+                "vkr_percent": 2.5,
+                "pfe_kw": 0.0,
+                "i0_percent": 0.0,
+                "shift_degree": 0.0,
+                "tap_side": None,
+                "tap_neutral": numpy.NAN,
+                "tap_min": numpy.NAN,
+                "tap_max": numpy.NAN,
+                "tap_step_percent": numpy.NAN,
+                "tap_step_degree": numpy.NAN,
+                "tap_pos": numpy.NAN,
+                "tap_phase_shifter": False,
+                "parallel": 1,
+                "df": 1.0,
+                "in_service": True,
+                "pt_percent": numpy.NAN,
+                "vector_group": "Dyn",
+                "oltc": 0
+            }
+        ],
+        "trafo",
+        log=True
+    )
+
+    validate_pp_load_flow_results(
+        pp_network.line,
+        [
+            {
+                "name": "Line",
+                "std_type": None,
+                "from_bus": tx_lv_bus,
+                "to_bus": load_bus,
+                "length_km": 0.1,
+                "r_ohm_per_km": 0.642,
+                "x_ohm_per_km": 0.083,
+                "c_nf_per_km": 0.0,
+                "g_us_per_km": 0.0,
+                "max_i_ka": 0.142,
+                "df": 1.0,
+                "parallel": 1,
+                "type": None,
+                "in_service": True
+            }
+        ],
+        "line",
+        log=True
+    )
+
+    validate_pp_load_flow_results(
+        pp_network.load,
+        [
+            {
+                "name": "Load_load",
+                "bus": load_bus,
+                "p_mw": 0.1,
+                "q_mvar": 0.05,
+                "const_z_percent": 0.0,
+                "const_i_percent": 0.0,
+                "sn_mva": pp.nan,
+                "scaling": 1.0,
+                "in_service": True,
+                "type": "wye"
+            }
+        ],
+        "load",
+        log=True
+    )
+
+    validate_pp_load_flow_results(
+        pp_network.ext_grid,
+        [
+            {
+                "name": "Grid Connection",
+                "bus": tx_hv_bus,
+                "vm_pu": 1.02,
+                "va_degree": 0.0,
+                "in_service": True,
+                "slack_weight": 1.0
+            }
+        ],
+        "ext_grid",
+        log=True
+    )


### PR DESCRIPTION
# Description

Fixes bug where `BasicPandaPowerNetworkCreator` cannot translate lines in the bus branch model without an associated location in the node breaker model. Also updates the SDK version to 0.35.0b9 to resolve a dependency conflict.

# Associated tasks:

Tasks blocking this one:
- [x] Merge https://github.com/zepben/evolve-sdk-python/pull/123

Tasks this is blocking:
- https://github.com/zepben/ewb-sdk-examples-python/pull/3

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have updated the changelog.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so. (not breaking)
