### PR TITLE
[EWB-4509] fix package naming to use dash and not underscore

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,9 @@ commands =
 #    bash -ec 'if [[ -n $COVERALLS_REPO_TOKEN ]]; then coveralls; fi'
     python setup.py bdist_wheel
 
+    # The build above creates a `pp_translator...` wheel (with underscore), so let's rename it back to the expected `pp-translator...`
+    bash -ec 'for pkg in dist/pp_*py3-none-any.whl; do new_name=$(echo $pkg | sed -e "s/pp_/pp-/g"); mv $pkg ${new_name}; done'
+
 [pytest]
 log_file_level = DEBUG
 log_file = pytest.log


### PR DESCRIPTION
# Description

Rename the wheel created by the `python setup bdist_wheel`, replacing underscore with the expected dash.


# Test Steps

Explain in detail how your reviewer can test the changes proposed in this PR. If it cannot be tested, leave an explanation on why.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

### Documentation
~- [ ] I have updated the changelog.~
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Not a breaking change.